### PR TITLE
move eslint and eslint-plugin-react into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,11 @@
   "scripts": {
     "test": "jest"
   },
-  "devDependencies": {
+  "dependencies": {
     "eslint": "^6.1.0",
-    "eslint-plugin-react": "^7.14.3",
-    "jest": "^24.8.0"
-  },
-  "peerDependencies": {
-    "eslint": ">= 3",
     "eslint-plugin-react": "^7.14.3"
+  },
+  "devDependencies": {
+    "jest": "^24.8.0"
   }
 }

--- a/src/js/rules/stylistic-issues.js
+++ b/src/js/rules/stylistic-issues.js
@@ -116,7 +116,7 @@ module.exports = {
                 capIsNew: false,
             },
         ],
-        'new-parens': ['error', 'always'],
+        'new-parens': 'error',
         'newline-per-chained-call': [
             'error',
             {


### PR DESCRIPTION
- Move `eslint` and `eslint-plugin-react` into dependencies.
- Update `new-parens` rule so that it works with eslint versions < 6.