### PR TITLE
Use short name in examples instead of long name.

### DIFF
--- a/packages/eslint-config-twilio-react/README.md
+++ b/packages/eslint-config-twilio-react/README.md
@@ -24,7 +24,7 @@ Add the ESLint config to either your `package.json` or your `.eslintrc`:
   "name": "my-project",
   "eslintConfig": {
     "extends": [
-      "eslint-config-twilio-react"
+      "twilio-react"
     ]
   }
 }
@@ -35,7 +35,7 @@ Add the ESLint config to either your `package.json` or your `.eslintrc`:
 ```json
 {
   "extends": [
-    "eslint-config-twilio-react"
+    "twilio-react"
   ]
 }
 ```

--- a/packages/eslint-config-twilio/README.md
+++ b/packages/eslint-config-twilio/README.md
@@ -24,7 +24,7 @@ Add the ESLint config to either your `package.json` or your `.eslintrc`:
   "name": "my-project",
   "eslintConfig": {
     "extends": [
-      "eslint-config-twilio"
+      "twilio"
     ]
   }
 }
@@ -35,7 +35,7 @@ Add the ESLint config to either your `package.json` or your `.eslintrc`:
 ```json
 {
   "extends": [
-    "eslint-config-twilio"
+    "twilio"
   ]
 }
 ```


### PR DESCRIPTION
The example in the readme uses the long name for the name of the config. It is also possible to use the short name here and I think that looks nicer. This is a personal opinion so feel free to close this PR.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
