### PR TITLE
update linter to follow more of the prettier rationale

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "files": [
-    "README.md"
+    "CONTRIBUTORS.md"
   ],
   "imageSize": 100,
   "commit": false,

--- a/packages/eslint-config-twilio/rules/stylistic-issues.js
+++ b/packages/eslint-config-twilio/rules/stylistic-issues.js
@@ -44,7 +44,7 @@ module.exports = {
     'func-call-spacing': ['error', 'never'],
     'func-name-matching': ['off'],
     'func-names': ['warn', 'as-needed'],
-    'func-style': 'warn',
+    'func-style': ['warn', 'declaration'],
     'function-paren-newline': ['error', 'multiline'],
     'id-blacklist': 'off',
     'id-length': 'off',

--- a/packages/eslint-config-twilio/rules/stylistic-issues.js
+++ b/packages/eslint-config-twilio/rules/stylistic-issues.js
@@ -72,8 +72,7 @@ module.exports = {
     'lines-around-comment': [
       'error',
       {
-        beforeBlockComment: true,
-        beforeLineComment: true,
+        beforeBlockComment: false,
       },
     ],
     'lines-between-class-members': [
@@ -86,7 +85,7 @@ module.exports = {
     'max-depth': ['warn', 5],
     'max-len': [
       'error',
-      100,
+      120,
       2,
       {
         ignoreUrls: true,


### PR DESCRIPTION
- updated `max-len` to 120
- [empty lines at start/end of blocks](https://prettier.io/docs/en/rationale.html#empty-lines)
  - with our current linter, we require an empty line before a comment, but if that comment is at the beginning of a block, prettier would remove it
- update `func-style` to suggest `declaration`