### PR TITLE
fixed Expected linebreaks to be 'LF' but found 'CRLF' linebreak-style issue in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "type": "git",
     "url": "git+https://github.com/twilio-labs/twilio-style.git"
   },
+ "rules": {
+ "linebreak-style": 0,
+ "global-require": 0,
+ "eslint linebreak-style": [0, "error", "windows"],
+  
   "license": "MIT",
   "author": "Twilio @twilio",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
  "linebreak-style": 0,
  "global-require": 0,
  "eslint linebreak-style": [0, "error", "windows"],
+ },
   
   "license": "MIT",
   "author": "Twilio @twilio",


### PR DESCRIPTION
<!--   -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
