### PR TITLE
fix vulnerabilities found with npm audit and bump typescript to 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2529,7 +2529,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "optional": true
     },
     "compare-func": {
@@ -4689,10 +4688,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
-      "dev": true,
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -6575,8 +6573,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -6902,7 +6899,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -6911,8 +6907,7 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
@@ -8036,8 +8031,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -8572,7 +8566,6 @@
       "version": "3.6.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
       "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -8886,8 +8879,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/packages/eslint-config-twilio-react/package-lock.json
+++ b/packages/eslint-config-twilio-react/package-lock.json
@@ -376,9 +376,9 @@
       }
     },
     "eslint-config-twilio": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-twilio/-/eslint-config-twilio-1.19.1.tgz",
-      "integrity": "sha512-xpRhU5YkVlnCAUSmUl9EnK1baoJNqmGsAsj2ToPALVymWHnlGYjRgC8nqVnXmgJuYqp93M09DwOjae7FAkKeQg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-twilio/-/eslint-config-twilio-1.19.2.tgz",
+      "integrity": "sha512-sQwVFw4a/XBKRoKEzXJ8MWIvng2P1nDndSZV6KIGfKIkvT0ef3BzfFqJos0npy9vmKrxvjf7ixx18Dlegt+7ig==",
       "requires": {
         "eslint-config-prettier": "^6.5.0",
         "eslint-config-twilio-base": "^1.19.0",

--- a/packages/eslint-config-twilio-ts/package-lock.json
+++ b/packages/eslint-config-twilio-ts/package-lock.json
@@ -381,9 +381,9 @@
 			}
 		},
 		"eslint-config-twilio": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-twilio/-/eslint-config-twilio-1.19.1.tgz",
-			"integrity": "sha512-xpRhU5YkVlnCAUSmUl9EnK1baoJNqmGsAsj2ToPALVymWHnlGYjRgC8nqVnXmgJuYqp93M09DwOjae7FAkKeQg==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/eslint-config-twilio/-/eslint-config-twilio-1.19.2.tgz",
+			"integrity": "sha512-sQwVFw4a/XBKRoKEzXJ8MWIvng2P1nDndSZV6KIGfKIkvT0ef3BzfFqJos0npy9vmKrxvjf7ixx18Dlegt+7ig==",
 			"requires": {
 				"eslint-config-prettier": "^6.5.0",
 				"eslint-config-twilio-base": "^1.19.0",
@@ -1461,9 +1461,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
 		},
 		"uri-js": {
 			"version": "4.2.2",

--- a/packages/eslint-config-twilio-ts/package.json
+++ b/packages/eslint-config-twilio-ts/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
     "eslint-config-twilio": "^1.19.2",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "devDependencies": {
     "eslint": "^6.6.0"


### PR DESCRIPTION
- fix vulnerabilities found with `npm audit`
- bump typescript to `3.7.2`