### PR TITLE
typescript rule updates

### DIFF
--- a/packages/eslint-config-twilio-ts/rules/typescript.js
+++ b/packages/eslint-config-twilio-ts/rules/typescript.js
@@ -31,7 +31,10 @@ module.exports = {
     },
   ],
   '@typescript-eslint/no-require-imports': 'error',
-  '@typescript-eslint/no-unnecessary-condition': 'error',
+  '@typescript-eslint/no-unnecessary-condition': [
+    'error',
+    { ignoreRhs: true },
+  ],
 
   // We must disable the base rule as it can report incorrect errors.
   'no-useless-constructor': 'off',

--- a/packages/eslint-config-twilio-ts/rules/typescript.js
+++ b/packages/eslint-config-twilio-ts/rules/typescript.js
@@ -31,7 +31,9 @@ module.exports = {
     },
   ],
   '@typescript-eslint/no-require-imports': 'error',
-  '@typescript-eslint/no-unnecessary-condition': ['error', { ignoreRhs: true }],
+
+  // Turning this rule off until https://github.com/typescript-eslint/typescript-eslint/pull/1163 gets merged.
+  '@typescript-eslint/no-unnecessary-condition': 'off',
 
   // We must disable the base rule as it can report incorrect errors.
   'no-useless-constructor': 'off',

--- a/packages/eslint-config-twilio-ts/rules/typescript.js
+++ b/packages/eslint-config-twilio-ts/rules/typescript.js
@@ -31,10 +31,7 @@ module.exports = {
     },
   ],
   '@typescript-eslint/no-require-imports': 'error',
-  '@typescript-eslint/no-unnecessary-condition': [
-    'error',
-    { ignoreRhs: true },
-  ],
+  '@typescript-eslint/no-unnecessary-condition': ['error', { ignoreRhs: true }],
 
   // We must disable the base rule as it can report incorrect errors.
   'no-useless-constructor': 'off',
@@ -45,17 +42,6 @@ module.exports = {
   '@typescript-eslint/promise-function-async': 'error',
   '@typescript-eslint/require-array-sort-compare': 'error',
   '@typescript-eslint/restrict-plus-operands': 'error',
-  '@typescript-eslint/typedef': [
-    'error',
-    {
-      arrayDestructuring: false,
-      arrowParameter: false,
-      memberVariableDeclaration: true,
-      objectDestructuring: false,
-      parameter: true,
-      propertyDeclaration: true,
-      variableDeclaration: false,
-    },
-  ],
+  '@typescript-eslint/typedef': 'off',
   '@typescript-eslint/unified-signatures': 'error',
 };


### PR DESCRIPTION
- turn off `@typescript-eslint/typedef` based on `@typescript-eslint` recommendation
- turn off  `@typescript-eslint/no-unnecessary-condition` until it's fixed