### PR TITLE
fix prettier config order

### DIFF
--- a/packages/eslint-config-twilio/index.js
+++ b/packages/eslint-config-twilio/index.js
@@ -3,7 +3,7 @@ const rules = require('./rules');
 const allExtensions = ['.ts', '.tsx', '.d.ts', '.js', '.jsx'];
 
 module.exports = {
-  extends: ['prettier', 'twilio-base'],
+  extends: ['twilio-base', 'prettier'],
   plugins: ['import', 'prettier'],
   settings: {
     'import/extensions': allExtensions,


### PR DESCRIPTION
An issue I've ran into while using prettier with eslint-config-twilio is that prettier and eslint conflict (eslint will fix formatting, and then prettier will overwrite those fixes). By placing the `prettier` config last, the eslint rules will be overwritten/ignored so no conflicts will happen.

from https://github.com/prettier/eslint-config-prettier#installation:

> Then, add eslint-config-prettier to the "extends" array in your .eslintrc.* file. Make sure to put it last, so it gets the chance to override other configs.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
