### PR TITLE
Fix Prettier rules

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  trailingComma: "all",
+  trailingComma: 'all',
   singleQuote: true,
   printWidth: 120,
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  trailingComma: 'all',
+  trailingComma: "all",
   singleQuote: true,
   printWidth: 120,
 };

--- a/packages/eslint-config-twilio/rules/index.js
+++ b/packages/eslint-config-twilio/rules/index.js
@@ -2,6 +2,11 @@
 
 module.exports = {
   ...require('./overrides'),
-  ...require('./prettier'),
   ...require('./import'),
+  'prettier/prettier': [
+    'error',
+    {
+      ...require('./prettier'),
+    },
+  ],
 };


### PR DESCRIPTION
According to the Readme, I should be able to create a `.prettierrc.js` in my project, them import the `baseConfig` from `./node_modules/eslint-config-twilio/rules/prettier`.
That config is not a Prettier but a ESLint one so, when adding that baseRules to my Prettier configuration, nothing no rules are applied.

This fix is about exporting the correct Prettier rules from `rules/prettier.js` and also add a Prettier configuration to this project to maintain code style in this repo

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
