### PR TITLE
fix: add ignore stateless to react/no-multi-comp

### DIFF
--- a/packages/eslint-config-twilio-react/rules/react.js
+++ b/packages/eslint-config-twilio-react/rules/react.js
@@ -53,7 +53,7 @@ module.exports = {
   'react/no-direct-mutation-state': 'error',
   'react/no-find-dom-node': 'error',
   'react/no-is-mounted': 'error',
-  'react/no-multi-comp': 'warn',
+  'react/no-multi-comp': ['error', {ignoreStateless: true}],
   'react/no-redundant-should-component-update': 'error',
   'react/no-render-return-value': 'error',
   'react/no-set-state': 'off',


### PR DESCRIPTION
Currently, the rule is: `'react/no-multi-comp': 'warn',`
It is better to make the rule: 'react/no-multi-comp': ['error', {ignoreStateless: true}],

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md#ignorestateless

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
