### PR TITLE
fix: improve the jsx-a11y/label-has-associated-control rule

### DIFF
--- a/packages/eslint-config-twilio-react/rules/a11y.js
+++ b/packages/eslint-config-twilio-react/rules/a11y.js
@@ -41,13 +41,10 @@ module.exports = {
   'jsx-a11y/img-redundant-alt': 'error',
   'jsx-a11y/interactive-supports-focus': 'error',
   'jsx-a11y/label-has-associated-control': [
-    'error',
+    2,
     {
-      labelComponents: [],
-      labelAttributes: [],
-      controlComponents: [],
-      assert: 'both',
-      depth: 25,
+      assert: 'either',
+      depth: 3,
     },
   ],
   'jsx-a11y/lang': 'error',


### PR DESCRIPTION
This improves the twilio-style `jsx-a11y/label-has-associated-control` rule to match what Paste uses.

It is an improvement because:
* for accessibility, you do not need to have _both_ the input within a label and to have the HTMLFor attribute. It just needs one or the other
* for code clarity, the input should not be nested 25 layers away from the input. 3 should be enough.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
